### PR TITLE
Add man page and bash completion support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PKGNAME		= fde-tools-0.6.3
+PKGNAME		= fde-tools-$(shell ./fde.sh --version)
 
 CCOPT		= -O0 -g
 SBINDIR		= /sbin
@@ -27,7 +27,11 @@ LIBSCRIPTS	= grub2 \
 
 _LIBSCRIPTS	= $(addprefix share/,$(LIBSCRIPTS))
 
-all: $(TOOLS)
+SUBDIRS := man
+
+.PHONY: all install $(SUBDIRS)
+
+all:: $(TOOLS) $(SUBDIRS)
 
 install:: $(TOOLS)
 	install -d $(DESTDIR)/bin
@@ -48,6 +52,14 @@ install::
 	@install -m 555 -v fde.sh $(DESTDIR)$(SBINDIR)/fdectl
 	@install -m 755 -v -d $(DESTDIR)$(FDE_CONFIG_DIR)
 
+$(SUBDIRS):
+	$(MAKE) -C $@
+
+install:: $(SUBDIRS)
+	@for d in $(SUBDIRS); do \
+		$(MAKE) -C $$d install; \
+	done
+
 clean:
 	rm -f $(TOOLS)
 	rm -rf build
@@ -61,7 +73,7 @@ build/%.o: src/%.c
 
 dist:
 	mkdir -p $(PKGNAME)
-	cp -a Makefile sysconfig.fde fde.sh src share firstboot $(PKGNAME)
+	cp -a Makefile sysconfig.fde fde.sh src share firstboot $(SUBDIRS) $(PKGNAME)
 	@find $(PKGNAME) -name '.*.swp' -o -name '*.{rej,orig}' | xargs -rt rm
 	tar -cvjf $(PKGNAME).tar.bz2 $(PKGNAME)/*
 	rm -rf $(PKGNAME)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ LIBSCRIPTS	= grub2 \
 
 _LIBSCRIPTS	= $(addprefix share/,$(LIBSCRIPTS))
 
-SUBDIRS := man
+SUBDIRS := man bash-completion
 
 .PHONY: all install $(SUBDIRS)
 

--- a/TODO
+++ b/TODO
@@ -1,6 +1,5 @@
 
 To be done:
- - add manpage
  - add-secondary-key: make sure we really only have two keys
  - tpm-disable: implement
  - add/remove-secondary-pass: needs testing

--- a/bash-completion/Makefile
+++ b/bash-completion/Makefile
@@ -1,0 +1,8 @@
+COMPLETION_DIR := $(DESTDIR)/usr/share/bash-completion/completions
+
+all:
+
+install:
+	@install -d $(COMPLETION_DIR)
+	@install -m 644 fdectl $(COMPLETION_DIR)
+

--- a/bash-completion/fdectl
+++ b/bash-completion/fdectl
@@ -1,0 +1,48 @@
+# bash completion for fdectl        -*- shell-script -*-
+
+__get_block_devices() {
+    local i
+    for i in /dev/*; do
+        [ -b "$i" ] && printf '%s\n' "$i"
+    done
+}
+
+_fdectl() {
+    local cur prev opts
+
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "${prev}" in
+    --bootloader)
+        COMPREPLY=( $(compgen -W "grub2 systemd-boot" -- ${cur}) )
+        return 0
+        ;;
+    --keyfile)
+        COMPREPLY=( $(compgen -f -- ${cur}) )
+        return 0
+        ;;
+    --device)
+        local bdevs
+        bdevs=$(__get_block_devices)
+        COMPREPLY=( $(compgen -W "${bdevs}" -- ${cur}) )
+        return 0
+        ;;
+    --uefi-boot-dir)
+        compopt -o filenames
+        COMPREPLY=( $(compgen -d -- ${cur}) )
+        return 0
+        ;;
+    esac
+
+    opts=$( fdectl --help 2>&1 |
+            awk '/^\s*--/ {print $1; next}
+            /^Commands/ {c = 1; next}
+            c == 1 {print $1}' )
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+}
+
+complete -F _fdectl fdectl
+
+# ex: ts=4 sw=4 et filetype=sh

--- a/fde.sh
+++ b/fde.sh
@@ -22,7 +22,7 @@ shopt -s expand_aliases
 
 : ${SHAREDIR:=/usr/share/fde}
 
-. $SHAREDIR/luks
+version=0.6.3
 
 opt_bootloader=grub2
 opt_uefi_bootdir=""
@@ -37,13 +37,15 @@ opt_password=""
 ##################################################################
 function fde_usage {
 
-    cat >&2 <<EOF
+    cat <<EOF
 
-Usage: fde [global-options] command [cmd-options]
+Usage: fdectl [global-options] command [cmd-options]
 
 Global options:
   --help
 	Display this message
+  --version
+	Print program version 
   --device
 	Specify the partition to operate on. Can be a device
 	name or a mount point. Defaults to the current root
@@ -61,13 +63,13 @@ Global options:
 	installer only.
 
 Commands:
-  help - display this message
-  passwd - change the password protecting the partition
-  add-secondary-password - protect partition with a passphrase and use that to unlock on next boot
-  remove-secondary-password - remove passphrase installed by add-secondary-password
-  tpm-present - check whether a TPM2 chip is present and working
-  tpm-enable - enable TPM protection
-  tpm-disable - disable TPM protection
+  help		display this message
+  passwd	change the password protecting the partition
+  add-secondary-password	protect partition with a passphrase and use that to unlock on next boot
+  remove-secondary-password	remove passphrase installed by add-secondary-password
+  tpm-present	check whether a TPM2 chip is present and working
+  tpm-enable	enable TPM protection
+  tpm-disable	disable TPM protection
 EOF
 }
 
@@ -117,7 +119,7 @@ function fde_maybe_chroot {
 
 fde_maybe_chroot "$@"
 
-long_options="help,bootloader:,device:,use-dialog,keyfile:,uefi-boot-dir:,password:"
+long_options="help,version,bootloader:,device:,use-dialog,keyfile:,uefi-boot-dir:,password:"
 
 if ! getopt -Q -n fdectl -l "$long_options" -o h -- "$@"; then
     fde_usage
@@ -136,6 +138,9 @@ while [ $# -gt 0 ]; do
 	command=$1; shift; break;;
     -h|--help)
     	fde_usage
+	exit 0;;
+    --version)
+	echo "$version"
 	exit 0;;
     --bootloader)
     	opt_bootloader=$1; shift;;
@@ -176,6 +181,7 @@ fi
 
 trap fde_clean_tempdir 0 1 2 11 15
 
+. "$SHAREDIR/luks"
 . "$SHAREDIR/uefi"
 if [ -n "$opt_uefi_bootdir" ]; then
     uefi_set_loader "$opt_uefi_bootdir"

--- a/man/Makefile
+++ b/man/Makefile
@@ -1,0 +1,11 @@
+MANDIR := $(DESTDIR)/usr/share/man
+vpath %.sh ../
+
+all: fdectl.8
+
+fdectl.8: fdectl.h2m fde.sh
+	help2man --no-info --section=8 -i $< -o $@ $(shell echo $^ | awk '{print $$2}')
+
+install: all
+	@install -d $(MANDIR)/man8
+	@install -m 644 fdectl.8 $(MANDIR)/man8

--- a/man/fdectl.h2m
+++ b/man/fdectl.h2m
@@ -1,0 +1,59 @@
+[NAME]
+fdectl \- Tool for controlling Full Disk Encryption
+
+[DESCRIPTION]
+The primary objective of this tool is to streamline the TPM seal/unseal process
+for system administrators and installers. To achieve this, it heavily depends
+on \fBpcr-oracle\fP to forecast the relevant TPM Platform Configuration
+Registers (PCRs) values at the point when the boot loader needs to unseal the
+key. The primary configuration file for this tool is located at
+\fB/etc/sysconfig/fde-tools\fP.
+
+[EXAMPLES]
+Testing for the presence of a TPM
+
+.B
+.nf
+fdectl tpm-present
+.PP
+.fi
+
+This will return an exit status of 0 (success) or 1 (absent).
+
+If the users asks for the LUKS partition to be protected by the TPM, the
+installer needs to create a secondary key and pass this to the installed
+system, like this:
+
+.B
+.nf
+fdectl add-secondary-key --keyfile /root/.root.key
+.PP
+.fi
+
+This will prompt for the recovery password that is able to unlock the LUKS
+partition. Alternatively, you can pass the password on the command like using
+the \fI--password\fP option.
+
+After booting into the installed system, TPM protection needs to be enabled
+using this command:
+
+.B
+.nf
+fdectl tpm-enable --keyfile /root/.root.keyfile
+.PP
+.fi
+
+This will create a _new_ LUKS key, which is then sealed against the predicted
+TPM state, and installed in the UEFI System Partition. The old key, which was
+created by the installer, is removed.
+
+Note, when using \fBfdectl add-secondary-password\fP as described above,
+\fItpm-enable\fP will also have to remove this well-known password from the
+LUKS header.
+
+Usually, the \fItpm-enable\fP command is invoked automatically on first boot
+via the \fBfde-tools.service\fP unit file.
+
+[SEE ALSO]
+.BR pcr-oracle (8),
+.BR cryptsetup (8)


### PR DESCRIPTION
I believe the title is self-explanatory, and this requires a modification to the spec file.

```
--- fde-tools.spec      (revision 15)
+++ fde-tools.spec      (working copy)
@@ -30,6 +30,7 @@
 BuildRequires:  openssl >= 0.9.8
 BuildRequires:  tpm2-0-tss-devel
 BuildRequires:  dracut
+BuildRequires:  help2man
 Requires:      pcr-oracle >= 0.4.2
 Requires:      cryptsetup
 # Requires:    tpm2.0-tools
@@ -88,6 +89,9 @@
 %{_fillupdir}/sysconfig.*
 %{_datadir}/fde
 %{_unitdir}/fde-tpm-enroll.service
+%dir %{_datadir}/bash-completion/completions/
+%{_mandir}/man8/fdectl.8.*
+%{_datadir}/bash-completion/completions/fdectl
```
